### PR TITLE
A few nitpicks after today's work

### DIFF
--- a/app/screens/Login.js
+++ b/app/screens/Login.js
@@ -25,6 +25,7 @@ class TextField extends Component {
         onChangeText={(value) => onChange(value)}
         underlineColorAndroid="transparent"
         selectTextOnFocus={true}
+        placeholder={this.props.name}
         {...this.props}
       />
     );
@@ -77,6 +78,7 @@ const styles = StyleSheet.create({
     marginBottom: 5
   }
 })
+
 const formName = 'login'
 const form = reduxForm({ form: formName })(Login)
 const selector = formValueSelector(formName)

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,19 +1,12 @@
 import { createStore, applyMiddleware } from 'redux'
-import { combineReducers } from 'redux'
-import { reducer as formReducer } from 'redux-form'
 
 import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 
+import rootReducer from './reducer'
+
 // TODO: get env to match reality
 const ENV = 'DEBUG'
-
-import * as session from '../modules/session'
-
-const rootReducer = combineReducers({
-  [session.NAME]: session.reducer,
-  form: formReducer,
-})
 
 const configMiddleware = () => {
   if (ENV === 'RELEASE') {

--- a/app/store/reducer.js
+++ b/app/store/reducer.js
@@ -1,0 +1,11 @@
+import { combineReducers } from 'redux'
+import { reducer as formReducer } from 'redux-form'
+
+// IMPORT_REDUCERS
+import * as session from '../modules/session'
+
+// COMBINE_REDUCERS
+export default combineReducers({
+  [session.NAME]: session.reducer,
+  form: formReducer,
+})

--- a/package.json
+++ b/package.json
@@ -46,29 +46,13 @@
       }
     },
     "rules": {
-      "semi": [
-        2,
-        "never"
-      ],
+      "semi": [ 2, "never" ],
       "comma-dangle": ["always"],
-      "no-trailing-spaces": [
-        "error",
-        {
-          "skipBlankLines": true
-        }
-      ],
-      "max-len": [
-        "error",
-        80,
-        2,
-        {
-          "ignoreUrls": true
-        }
-      ]
+      "no-trailing-spaces": [ "error", { "skipBlankLines": true } ],
+      "max-len": [ "error", 80, 2, { "ignoreUrls": true } ],
+      "react/jsx-uses-vars": [2]
     },
-    "plugins": [
-      "react"
-    ]
+    "plugins": [ "react" ]
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,0 @@
-- install navigation
-- link nav to a screen with default stuff
-- install redux form
-- link simple login for to simple reducer
-- propose module / app structure
-- reselect?


### PR DESCRIPTION
_Why_?
- todo text file was still hanging out
- root reducer won't be as explicit when inside of create store method
- package.json eslint was a bit verbose

_How_?
- rm'd todo.txt
- removed unnecessary spacing in eslint configs in package.json
- added placeholder text to the basic form
- pulled root reducer to its own file within store directory so we
  can later more easily automate the addition of new stores through a
  templating tool

_Side Effects_?

no.
