### PR TITLE
Proposal: hashing out ideas for API middleware

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,13 +1,13 @@
-import { Provider } from 'react-redux';
+import { Provider } from 'react-redux'
 import { Navigation } from 'react-native-navigation'
 
 import { registerScreens } from './screens'
 
-import configureStore from './store';
+import configureStore from './store'
 
-const store = configureStore();
+const store = configureStore()
 
-registerScreens(store, Provider);
+registerScreens(store, Provider)
 
 export default class App {
   constructor() {

--- a/app/middlewares/callAPIMiddleware.js
+++ b/app/middlewares/callAPIMiddleware.js
@@ -1,0 +1,52 @@
+const typesAreValid = (types) => {
+  return (
+    Array.isArray(types) &&
+    types.length === 3 &&
+    types.every(type => typeof type === 'string')
+  )
+}
+
+export default function callAPIMiddleware({ dispatch, getState }) {
+  return next => action => {
+    const {
+      types,
+      callAPI,
+      shouldCallAPI = () => true,
+      payload = {},
+      onSuccess = () => undefined,
+    } = action
+
+    if (!types) {
+      // Normal action: pass it on
+      return next(action)
+    }
+
+
+    if (!typesAreValid(types)) {
+      throw new Error('Expected an array of three string types.')
+    }
+
+    if (typeof callAPI !== 'function') {
+      throw new Error('Expected callAPI to be a function.')
+    }
+
+    if (typeof onSuccess !== 'function') {
+      throw new Error('Expected onSuccess to be a function.')
+    }
+
+    if (!shouldCallAPI(getState())) return
+
+    const [ requestType, successType, failureType ] = types
+
+    dispatch({ ...payload, type: requestType })
+
+    return callAPI().then(
+      response => {
+        dispatch({...payload, type: successType, ...response })
+        onSuccess()
+      },
+      error => dispatch({...payload, type: failureType, error })
+    )
+  }
+}
+

--- a/app/modules/session.js
+++ b/app/modules/session.js
@@ -1,17 +1,59 @@
 export const NAME = 'session'
 
-const LOAD   = `${NAME}/LOAD`
-const CREATE = `${NAME}/CREATE`
-const UPDATE = `${NAME}/UPDATE`
-const REMOVE = `${NAME}/REMOVE`
+const REQUEST = `${NAME}/LOGIN_REQUEST`
+const SUCCESS = `${NAME}/LOGIN_SUCCESS`
+const ERROR = `${NAME}/LOGIN_ERROR`
 
-export const reducer = (state = {}, action = {}) => {
+const initialState = {
+  email: null,
+}
+
+export const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
-    case LOAD:
-    case CREATE:
-    case UPDATE:
-    case REMOVE:
+    case SUCCESS:
+      return {
+        ...state,
+        email: action.email,
+        token: action.token
+      }
     default:
       return state
   }
+}
+
+function parseResponse(response) {
+  return response.data
+}
+
+function loginUser({ email, password }, onSuccess) {
+  return {
+    // this will be our signature for the middleware
+    // types: [REQUEST_TYPE, SUCCESS_TYPE, ERROR_TYPE],
+    types: [REQUEST, SUCCESS, ERROR],
+
+    // additional data that we are passing onto the reducer
+    // I'm not sure if this is necessary
+    payload: { email, password },
+
+    // here we determine if we should interact with the api
+    // in the middleware it passes getStore() to this method
+    shouldCallAPI: () => true,
+
+    // this will typically be a fetch("...").then(parseTheData)
+    callAPI: () => Promise.resolve({
+      data: {
+        user_id: 1234,
+        token: "a token",
+        email,
+      }
+    }).then(parseResponse),
+
+    // a callback that can be used for navigation redirects or anything else
+    // ex: const onSuccess = () => navigator.push({ screen: "Dashboard" })
+    onSuccess,
+  }
+}
+
+export const actions = {
+  loginUser,
 }

--- a/app/screens/Login.js
+++ b/app/screens/Login.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
+import { actions } from '../modules/session'
+
 import {
   formValueSelector,
   reduxForm,
@@ -10,39 +12,49 @@ import {
 import {
   StyleSheet,
   Text,
-  View,
   TextInput,
   ScrollView,
   TouchableOpacity,
 } from 'react-native'
 
-class TextField extends Component {
-  render(){
-    const { input: { value, onChange } } = this.props;
-    return (
-      <TextInput
-        style={{height: 40, borderColor: 'gray', borderWidth: 1}}
-        onChangeText={(value) => onChange(value)}
-        underlineColorAndroid="transparent"
-        selectTextOnFocus={true}
-        placeholder={this.props.name}
-        {...this.props}
-      />
-    );
-  }
+type TextFieldProps = {
+  input: Object,
+  name: String,
+}
+
+const TextField = (props: TextFieldProps) => {
+  const { input: { onChange } } = props
+
+  return (
+    <TextInput
+      style={{height: 40, borderColor: 'gray', borderWidth: 1}}
+      onChangeText={(value) => onChange(value)}
+      underlineColorAndroid="transparent"
+      selectTextOnFocus={true}
+      placeholder={props.name}
+      {...props}
+    />
+  )
+}
+
+type LoginProps = {
+  rdxForm: Object,
+  dispatch: Function,
+  navigator: Object,
 }
 
 class Login extends Component {
-  constructor(props) {
+  constructor(props: LoginProps) {
     super(props)
 
     this.submit = this.submit.bind(this)
   }
 
   submit() {
-    const { rdxForm } = this.props
+    const { rdxForm, dispatch, navigator } = this.props
+    const redirectAction = () => navigator.push({ screen: 'Login' })
 
-    console.log(rdxForm)
+    dispatch(actions.loginUser(rdxForm, redirectAction))
   }
 
   render() {

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,5 +1,7 @@
 import { createStore, applyMiddleware } from 'redux'
 
+import callAPIMiddleware from '../middlewares/callAPIMiddleware'
+
 import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 
@@ -10,9 +12,14 @@ const ENV = 'DEBUG'
 
 const configMiddleware = () => {
   if (ENV === 'RELEASE') {
-    return () => applyMiddleware(thunkMiddleware)
+    return () => applyMiddleware(thunkMiddleware, callAPIMiddleware)
   }
-  return () => applyMiddleware(thunkMiddleware, createLogger())
+
+  return () => applyMiddleware(
+    thunkMiddleware,
+    createLogger(),
+    callAPIMiddleware
+  )
 }
 
 const configureStore = (initialState) => {

--- a/index.android.js
+++ b/index.android.js
@@ -4,13 +4,13 @@
  * @flow
  */
 
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 import {
   AppRegistry,
   StyleSheet,
   Text,
   View
-} from 'react-native';
+} from 'react-native'
 
 class RNBooster extends Component {
   render() {
@@ -26,7 +26,7 @@ class RNBooster extends Component {
           Shake or press menu button for dev menu
         </Text>
       </View>
-    );
+    )
   }
 }
 
@@ -47,6 +47,6 @@ const styles = StyleSheet.create({
     color: '#333333',
     marginBottom: 5,
   },
-});
+})
 
-AppRegistry.registerComponent('RNBooster', () => RNBooster);
+AppRegistry.registerComponent('RNBooster', () => RNBooster)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "rules": {
       "semi": [ 2, "never" ],
-      "comma-dangle": ["always"],
+      "comma-dangle": [0, "always"],
       "no-trailing-spaces": [ "error", { "skipBlankLines": true } ],
       "max-len": [ "error", 80, 2, { "ignoreUrls": true } ],
       "react/jsx-uses-vars": [2]
@@ -57,7 +57,7 @@
   "devDependencies": {
     "babel-eslint": "^6.0.4",
     "babel-preset-react-native": "^1.9.0",
-    "eslint": "^2.13.0",
+    "eslint": "^3.5.0",
     "eslint-plugin-react": "^5.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
Note: I've also included some changes that eslint suggested

A proposal for addressing #6 

@jasontwong @davidmiller11  Here is the implementation of the API middleware that was in the redux docs. 

I kindof like it, we'll at least have a cleaner interface for interacting with the api's through our actions.

As it stands right now, we'd pass the following as the `callAPI` attribute on the action:

``` javascript
httpGet("http://api.service.com/whatever", { attributes }).then(parseData)

// or if we wanted to just grab the data later with reselect we could just do this
httpGet("http://api.service.com/whatever", { attributes })
```

Any thoughts?
